### PR TITLE
Added basic input and output systems to TetOS.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.exe
 build/
 *.bin
+*.map

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ run: $(TARGET).elf
 	qemu-system-riscv64 -machine virt -nographic -bios none -kernel $(TARGET).elf
 
 trace: $(TARGET).elf
-	qemu-system-riscv64 -machine virt -nographic -serial mon:stdio -bios none -kernel $(TARGET).elf -d guest_errors,unimp,mmu
+	qemu-system-riscv64 -machine virt -nographic -serial stdio -bios none -kernel $(TARGET).elf -d guest_errors,unimp,mmu
 
 clean:
 ifeq ($(OS),Windows_NT)

--- a/os/include/fdt_parser.h
+++ b/os/include/fdt_parser.h
@@ -1,9 +1,9 @@
+#ifndef FDT_PARSER_H
+#define FDT_PARSER_H
+
 #include <stdint.h>
 #include <stddef.h>
 #include <mini_lib.h>
-
-#ifndef FDT_PARSER_H
-#define FDT_PARSER_H
 
 typedef struct {
     uint32_t magic; // 0xd00dfeed

--- a/os/include/kernel.h
+++ b/os/include/kernel.h
@@ -1,0 +1,7 @@
+#ifndef KERNEL_H
+#define KERNEL_H
+
+#include <kprintf.h>
+int kernel_main(void);
+
+#endif // KERNEL_H

--- a/os/include/kernel.h
+++ b/os/include/kernel.h
@@ -2,6 +2,8 @@
 #define KERNEL_H
 
 #include <kprintf.h>
+#include <monitor.h>
+
 int kernel_main(void);
 
 #endif // KERNEL_H

--- a/os/include/kprintf.h
+++ b/os/include/kprintf.h
@@ -1,10 +1,10 @@
+#ifndef KPRINTF_H
+#define KPRINTF_H
+
 #include <stdarg.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <uart.h>
-
-#ifndef KPRINTF_H
-#define KPRINTF_H
 
 void kprintf(const char* format_string, ...);
 

--- a/os/include/kprintf.h
+++ b/os/include/kprintf.h
@@ -1,0 +1,11 @@
+#include <stdarg.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <uart.h>
+
+#ifndef KPRINTF_H
+#define KPRINTF_H
+
+void kprintf(const char* format_string, ...);
+
+#endif // KPRINTF_H

--- a/os/include/mini_lib.h
+++ b/os/include/mini_lib.h
@@ -6,7 +6,7 @@
 
 void* memcpy(void* dest, const void* src, size_t n);
 int strcmp(const char* s1, const char* s2);
-size_t strlen(const char* s);
+int strlen(const char* s);
 int memcmp(const void* a, const void* b, size_t n);
 void* memset(void* destination, int value, size_t n);
 void* memmove(void* destination, const void* source, size_t n);

--- a/os/include/mini_lib.h
+++ b/os/include/mini_lib.h
@@ -1,12 +1,12 @@
-#include <stdint.h>
-#include <stddef.h>
-
 #ifndef MINI_LIB_H
 #define MINI_LIB_H
 
+#include <stdint.h>
+#include <stddef.h>
+
 void* memcpy(void* dest, const void* src, size_t n);
 int strcmp(const char* s1, const char* s2);
-int strlen(const char* s);
+size_t strlen(const char* s);
 int memcmp(const void* a, const void* b, size_t n);
 void* memset(void* destination, int value, size_t n);
 void* memmove(void* destination, const void* source, size_t n);

--- a/os/include/monitor.h
+++ b/os/include/monitor.h
@@ -1,0 +1,11 @@
+#ifndef MONITOR_H
+#define MONITOR_H
+
+#include <kprintf.h>
+#include <mini_lib.h>
+#include <uart.h>
+#include <panic.h>
+
+void kernel_monitor();
+
+#endif // MONITOR_H

--- a/os/include/panic.h
+++ b/os/include/panic.h
@@ -1,0 +1,10 @@
+#ifndef PANIC_H
+#define PANIC_H
+
+#include <kprintf.h>
+
+#define panic(msg) _panic(msg, __FILE__, __LINE__, __func__)
+
+void _panic(const char* msg, const char* file, int line, const char* func);
+
+#endif // PANIC_H

--- a/os/include/sbi_init.h
+++ b/os/include/sbi_init.h
@@ -4,6 +4,8 @@
 #include <fdt_parser.h>
 #include <panic.h>
 
+#define UART_DEFAULT_MAP 0x10000000ull
+
 void sbi_init(const void* fdt_blob);
 
 #endif // SBI_INIT_H

--- a/os/include/sbi_init.h
+++ b/os/include/sbi_init.h
@@ -1,0 +1,9 @@
+#ifndef SBI_INIT_H
+#define SBI_INIT_H
+
+#include <fdt_parser.h>
+#include <panic.h>
+
+void sbi_init(const void* fdt_blob);
+
+#endif // SBI_INIT_H

--- a/os/include/uart.h
+++ b/os/include/uart.h
@@ -1,8 +1,8 @@
-#include <stdint.h>
-#include <stddef.h>
-
 #ifndef UART_H
 #define UART_H
+
+#include <stdint.h>
+#include <stddef.h>
 
 static volatile uintptr_t g_uart_base = 0; // Global UART base address
 

--- a/os/include/uart.h
+++ b/os/include/uart.h
@@ -30,5 +30,7 @@ typedef struct __attribute__((packed)) {
 void uart_init(uintptr_t base);
 void uart_putc(char c);
 void uart_puts(const char* str);
+char uart_getc(void);
+void uart_gets(char* buffer, size_t max_length);
 
 #endif // UART_H

--- a/os/include/uart.h
+++ b/os/include/uart.h
@@ -4,6 +4,8 @@
 #ifndef UART_H
 #define UART_H
 
+static volatile uintptr_t g_uart_base = 0; // Global UART base address
+
 // This is a big one:
 // __attribute__((packed)) ensures no padding is added by the compiler, this is necessary
 // because we are overlaying this struct on top of memory-mapped hardware registers.
@@ -26,7 +28,7 @@ typedef struct __attribute__((packed)) {
 #define UART(base) ((ns16550_8_t*) (uintptr_t) (base)) // Cast base address to struct pointer
 
 void uart_init(uintptr_t base);
-void uart_putc(uintptr_t base, char c);
-void uart_puts(uintptr_t base, const char* str);
+void uart_putc(char c);
+void uart_puts(const char* str);
 
 #endif // UART_H

--- a/os/src/boot/start.s
+++ b/os/src/boot/start.s
@@ -6,7 +6,7 @@ _start:
     mv a0, a1;
 
 1:
-    call sbi_init       /* C entry */
+    call kernel_entry      /* C entry */
 hang:
     wfi
     j       hang

--- a/os/src/drivers/uart.c
+++ b/os/src/drivers/uart.c
@@ -1,6 +1,7 @@
 #include <uart.h>
 
 void uart_init(uintptr_t base) {
+    g_uart_base = base;
     ns16550_8_t* uart = UART(base);
     uart->IER = 0x00; // Disable all interrupts (polling for boot)
     uart->FCR = 0x07; // Enable FIFO, clear RX/TX queues
@@ -8,17 +9,17 @@ void uart_init(uintptr_t base) {
     uart->MCR = 0x03; // RTS/DSR set
 }
 
-void uart_putc(uintptr_t base, char c) {
-    ns16550_8_t* uart = UART(base);
+void uart_putc(char c) {
+    ns16550_8_t* uart = UART(g_uart_base);
     while ((uart->LSR & (1 << 5)) == 0); // Wait for THR empty
     uart->THR = (uint8_t) c;
 }
 
-void uart_puts(uintptr_t base, const char* str) {
+void uart_puts(const char* str) {
     while (*str) {
         if (*str == '\n') {
-            uart_putc(base, '\r'); // Carriage return before newline
+            uart_putc('\r'); // Carriage return before newline
         }
-        uart_putc(base, *str++);
+        uart_putc(*str++);
     }
 }

--- a/os/src/kernel/kernel.c
+++ b/os/src/kernel/kernel.c
@@ -1,0 +1,20 @@
+#include <kernel.h>
+
+int kernel_main(void) {
+     // TetOS IS ALIVE
+    kprintf("Baguette crumbs of a new OS...\n");
+    kprintf("Test kprintf: char '%c', string \"%s\", int %d, uint %u, hex 0x%x, percent %%, nothing %t\n",
+            'A', "Stringing a chorus out of tune!", -1234, 5678u, 0x9abc);
+
+    // Echo
+    kprintf("Type characters to echo:\n");
+    kprintf("tetos> ");
+    char input[128];
+    while (1) {
+        uart_gets(input, sizeof(input));
+        kprintf("\nYou typed: %s\n", input);
+        kprintf("tetos> ");
+    }
+
+    return 0;
+}

--- a/os/src/kernel/kernel.c
+++ b/os/src/kernel/kernel.c
@@ -1,20 +1,9 @@
 #include <kernel.h>
+#include <monitor.h>
 
 int kernel_main(void) {
      // TetOS IS ALIVE
     kprintf("Baguette crumbs of a new OS...\n");
-    kprintf("Test kprintf: char '%c', string \"%s\", int %d, uint %u, hex 0x%x, percent %%, nothing %t\n",
-            'A', "Stringing a chorus out of tune!", -1234, 5678u, 0x9abc);
-
-    // Echo
-    kprintf("Type characters to echo:\n");
-    kprintf("tetos> ");
-    char input[128];
-    while (1) {
-        uart_gets(input, sizeof(input));
-        kprintf("\nYou typed: %s\n", input);
-        kprintf("tetos> ");
-    }
-
+    kernel_monitor(); 
     return 0;
 }

--- a/os/src/kernel/kernel.c
+++ b/os/src/kernel/kernel.c
@@ -1,5 +1,4 @@
 #include <kernel.h>
-#include <monitor.h>
 
 int kernel_main(void) {
      // TetOS IS ALIVE

--- a/os/src/kernel/kernel_entry.c
+++ b/os/src/kernel/kernel_entry.c
@@ -1,0 +1,9 @@
+#include <sbi_init.h>
+#include <kernel.h>
+
+// Pretty basic, probably want to do something more useful here
+void kernel_entry(const void* fdt_blob) {
+    sbi_init(fdt_blob);
+
+    kernel_main();
+}

--- a/os/src/kernel/kprintf.c
+++ b/os/src/kernel/kprintf.c
@@ -1,0 +1,96 @@
+#include <kprintf.h>
+
+static void print_value(int value, int base, int is_signed) {
+    char buffer[32]; // Enough for 32-bit binary representation + sign + null
+    char* p = &buffer[31]; // Reverse fill from the end
+    *p = '\0';
+
+    int is_negative = 0;
+    unsigned int uvalue;
+
+    // Handle negative numbers for signed decimal
+    if (is_signed && value < 0) {
+        is_negative = 1;
+        uvalue = (unsigned int) (-value);
+    } else {
+        uvalue = (unsigned int) value;
+    }
+
+    // Convert number to string in reverse order
+    if (uvalue == 0) {
+        *--p = '0';
+    } else {
+        while (uvalue > 0) {
+            int digit = uvalue % base;
+            *--p = (digit < 10) ? ('0' + digit) : ('a' + (digit - 10)); // Decode hex digits
+            uvalue /= base; // Unsigned division
+        }
+    }
+
+    // Add negative sign if needed
+    if (is_negative) {
+        *--p = '-';
+    }
+
+    uart_puts(p);
+}
+
+void kprintf(const char* format_string, ...) {
+    // va_list handles variable arguments
+    // va_start initializes it
+    va_list args;
+    va_start(args, format_string);
+
+    const char* p = format_string;
+    while (*p) {
+        // Need not apply
+        if (*p != '%') {
+            uart_putc(*p++);
+            continue;
+        }
+
+        p++; // Skip '%'
+        switch (*p) {
+            case 'c': {
+                // va_arg reads the next argument of the given type
+                char c = (char) va_arg(args, int); // char promoted to int, congratulations char o7
+                uart_putc(c);
+                break;
+            } // char
+            case 's': {
+                const char* str = va_arg(args, const char*);
+                uart_puts(str);
+                break;
+            } // char*
+            case 'i': // Also decimal because...?
+            case 'd':{
+                int value = va_arg(args, int);
+                print_value(value, 10, 1);
+                break;
+            } // decimal
+            case 'u': {
+                unsigned int uvalue = va_arg(args, unsigned int);
+                print_value(uvalue, 10, 0);
+                break;
+            } // unsigned decimal
+            case 'x': {
+                unsigned int hex = va_arg(args, unsigned int);
+                print_value(hex, 16, 0);
+                break;
+            } // hex
+            case '%': {
+                uart_putc('%');
+                break;
+            } // It's just a percent sign
+            default: {
+                uart_putc('%');
+                uart_putc(*p);
+                break;
+            } // Not s,i,d,u,x,c,%
+        }
+        p++; // Move past format specifier
+    }
+
+    // clean up
+    va_end(args);
+}

--- a/os/src/kernel/kprintf.c
+++ b/os/src/kernel/kprintf.c
@@ -62,7 +62,7 @@ void kprintf(const char* format_string, ...) {
                 uart_puts(str);
                 break;
             } // char*
-            case 'i': // Also decimal because...?
+            case 'i': // Also decimal because why not
             case 'd':{
                 int value = va_arg(args, int);
                 print_value(value, 10, 1);

--- a/os/src/kernel/monitor.c
+++ b/os/src/kernel/monitor.c
@@ -51,7 +51,7 @@ static int tokenize(char *input, char** argv, int max_args) {
     while (*input && argc < max_args) {
         // Skip leading whitespace
         while (*input == ' ' || *input == '\t' || *input == '\n' || *input == '\r') {
-            *input++; // This gives Wunused Value warning, but it's fine
+            (void) *input++; // (void) to suppress unused value warning
         }
 
         // End of string
@@ -62,7 +62,7 @@ static int tokenize(char *input, char** argv, int max_args) {
 
         // Find end of argument
         while (*input && *input != ' ' && *input != '\t' && *input != '\n' && *input != '\r') {
-            *input++;
+           (void) *input++;
         }
 
         // Null-terminate argument

--- a/os/src/kernel/monitor.c
+++ b/os/src/kernel/monitor.c
@@ -1,0 +1,105 @@
+#include <monitor.h>
+
+typedef int (*command_function_t) (int argc, char** argv);
+
+typedef struct {
+    const char* name;
+    const char* description;
+    command_function_t function;
+} command_t;
+
+static int command_help();
+static int command_echo(int argc, char** argv);
+static int command_panic();
+static int tokenize(char *input, char** argv, int max_args);
+
+static const command_t commands[] = {
+    {"help", "Display this help message", command_help},
+    {"echo", "Echo the input arguments", command_echo},
+    {"panic", "Trigger a kernel panic", command_panic},
+};
+
+#define NUM_COMMANDS (sizeof(commands) / sizeof(commands[0]))
+#define MAX_COMMAND_ARGS 16
+#define MAX_INPUT_LENGTH 128
+
+static int command_help() {
+    kprintf("Available commands:\n");
+    for (int i = 0; i < (int) NUM_COMMANDS; i++) {
+        kprintf("%s: %s\n", commands[i].name, commands[i].description);
+    }
+    return 0;
+}
+
+static int command_echo(int argc, char** argv) {
+    for (int i = 1; i < argc; i++) {
+        kprintf("%s%s", argv[i], (i < argc - 1) ? " " : ""); // Print space between arguments
+    }
+    kprintf("\n");
+    return 0;
+}
+
+// Top notch security right here
+static int command_panic() {
+    panic("User triggered panic via 'panic' command");
+    return 0; // Unreachable
+}
+
+static int tokenize(char *input, char** argv, int max_args) {
+    int argc = 0;
+    
+    while (*input && argc < max_args) {
+        // Skip leading whitespace
+        while (*input == ' ' || *input == '\t' || *input == '\n' || *input == '\r') {
+            *input++; // This gives Wunused Value warning, but it's fine
+        }
+
+        // End of string
+        if (!*input) break;
+
+        // Start of argument
+        argv[argc++] = input;
+
+        // Find end of argument
+        while (*input && *input != ' ' && *input != '\t' && *input != '\n' && *input != '\r') {
+            *input++;
+        }
+
+        // Null-terminate argument
+        if (!*input) break;
+        *input++ = '\0';
+    }
+
+    return argc;
+}
+
+void kernel_monitor() {
+    char input[MAX_INPUT_LENGTH];
+    char* argv[MAX_COMMAND_ARGS];
+
+    while (1) {
+        kprintf("tetos> ");
+        uart_gets(input, sizeof(input));
+
+        // Tokenize input
+        int argc = tokenize(input, argv, MAX_COMMAND_ARGS);
+        if (argc == 0) continue; // Empty input
+
+        // Find and execute command
+        int found = 0;
+        for (int i = 0; i < (int) NUM_COMMANDS; i++) {
+            if (strcmp(argv[0], commands[i].name) == 0) {
+                commands[i].function(argc, argv);
+                found = 1;
+                break;
+            }
+        }
+
+        if (!found) {
+            kprintf("Unknown command '%s'. Type 'help' for a list of commands.\n", argv[0]);
+        }
+
+        memset(input, 0, sizeof(input)); // Clear input buffer for next command
+        memset(argv, 0, sizeof(argv));   // Clear argv array for next command
+    }
+}

--- a/os/src/kernel/panic.c
+++ b/os/src/kernel/panic.c
@@ -1,0 +1,12 @@
+#include <panic.h>
+
+void _panic(const char* msg, const char* file, int line, const char* func) {
+    kprintf("\n*** KERNEL PANIC ***\n");
+    kprintf("Message: %s\n", msg);
+    kprintf("Location: %s:%d\n", file, line);
+    kprintf("Function: %s\n", func);
+
+    while (1) {
+        __asm__ volatile ("wfi"); // Hang
+    }
+}

--- a/os/src/kernel/sbi_init.c
+++ b/os/src/kernel/sbi_init.c
@@ -1,5 +1,6 @@
 #include <fdt_parser.h>
 #include <kprintf.h>
+#include <panic.h>
 
 void sbi_init(const void* fdt_blob) {
     // Build a view of the FDT
@@ -39,6 +40,9 @@ void sbi_init(const void* fdt_blob) {
     // Bring up UART
     g_uart_base   = (uintptr_t) base;
     uart_init(g_uart_base);
+
+    // Test panic
+    panic("boo"); // Get it because the kernel panics because it got scared
 
     // TetOS IS ALIVE
     kprintf("BOOT: FDT UART FOUND! @0x%x!\n", g_uart_base);

--- a/os/src/kernel/sbi_init.c
+++ b/os/src/kernel/sbi_init.c
@@ -1,6 +1,4 @@
-#include <fdt_parser.h>
-#include <kprintf.h>
-#include <panic.h>
+#include <sbi_init.h>
 
 void sbi_init(const void* fdt_blob) {
     // Build a view of the FDT
@@ -40,20 +38,4 @@ void sbi_init(const void* fdt_blob) {
     // Bring up UART
     g_uart_base   = (uintptr_t) base;
     uart_init(g_uart_base);
-
-    // TetOS IS ALIVE
-    kprintf("BOOT: FDT UART FOUND! @0x%x!\n", g_uart_base);
-    kprintf("Baguette crumbs of a new OS...\n");
-    kprintf("Test kprintf: char '%c', string \"%s\", int %d, uint %u, hex 0x%x, percent %%, nothing %t\n",
-            'A', "Stringing a chorus out of tune!", -1234, 5678u, 0x9abc);
-
-    // Echo
-    kprintf("Type characters to echo:\n");
-    kprintf("tetos> ");
-    char input[128];
-    while (1) {
-        uart_gets(input, sizeof(input));
-        kprintf("\nYou typed: %s\n", input);
-        kprintf("tetos> ");
-    }
 }

--- a/os/src/kernel/sbi_init.c
+++ b/os/src/kernel/sbi_init.c
@@ -1,13 +1,6 @@
 #include <fdt_parser.h>
 #include <uart.h>
 
-// Global for UART
-static volatile uintptr_t g_uart_base = 0;   // filled by FDT
-static uint64_t g_uart_size = 0;   // (not used yet, but handy to keep)
-static const char* g_uart_path = 0;   // e.g., "/soc/uart@10000000"
-static const char* g_uart_compat = 0; // e.g., "ns16550a"
-
-
 void sbi_init(const void* fdt_blob) {
     // Build a view of the FDT
     FDTView_t view;
@@ -24,7 +17,7 @@ void sbi_init(const void* fdt_blob) {
         // We don't have UART yet; use QEMU's default 0x10000000 as a last resort
         g_uart_base = 0x10000000ull;
         uart_init(g_uart_base);
-        uart_puts(g_uart_base, "BOOT: fdt_init failed, using hardcoded UART @0x10000000\n");
+        uart_puts("BOOT: fdt_init failed, using hardcoded UART @0x10000000\n");
         return;
     }
 
@@ -39,22 +32,15 @@ void sbi_init(const void* fdt_blob) {
         // Fallback: common QEMU virt mapping
         g_uart_base = 0x10000000ull;
         uart_init(g_uart_base);
-        uart_puts(g_uart_base, "BOOT: stdout UART not found in FDT; fallback @0x10000000\n");
+        uart_puts("BOOT: stdout UART not found in FDT; fallback @0x10000000\n");
         return;
     }
 
     // Bring up UART
     g_uart_base   = (uintptr_t) base;
-    g_uart_size   = size;
-    g_uart_path   = node_path;
-    g_uart_compat = compatible ? compatible : "";
-
     uart_init(g_uart_base);
 
     // TetOS IS ALIVE
-    uart_puts(g_uart_base, "BOOT: TetOS SBI early console ready\n");
-    uart_puts(g_uart_base, "Baguette crumbs of a new OS...\n");
-    uart_puts(g_uart_base, "Using UART abs_path=");
-    uart_puts(g_uart_base, g_uart_path);
-    uart_puts(g_uart_base, "\n");
+    uart_puts("BOOT: TetOS SBI early console ready\n");
+    uart_puts("Baguette crumbs of a new OS...\n");
 }

--- a/os/src/kernel/sbi_init.c
+++ b/os/src/kernel/sbi_init.c
@@ -14,7 +14,7 @@ void sbi_init(const void* fdt_blob) {
 
     if (fdt_init(&view, fdt_blob, blob_size) != 0) {
         // We don't have UART yet; use QEMU's default 0x10000000 as a last resort
-        g_uart_base = 0x10000000ull;
+        g_uart_base = UART_DEFAULT_MAP;
         uart_init(g_uart_base);
         panic("BOOT: fdt_init failed!");
         return;
@@ -29,7 +29,7 @@ void sbi_init(const void* fdt_blob) {
     int rc = fdt_resolve_stdout_uart(&view, &base, &size, &node_path, &compatible);
     if (rc != 0 || base == 0) {
         // Fallback: common QEMU virt mapping
-        g_uart_base = 0x10000000ull;
+        g_uart_base = UART_DEFAULT_MAP;
         uart_init(g_uart_base);
         panic("BOOT: stdout UART not found in FDT!");
         return;

--- a/os/src/kernel/sbi_init.c
+++ b/os/src/kernel/sbi_init.c
@@ -1,5 +1,5 @@
 #include <fdt_parser.h>
-#include <uart.h>
+#include <kprintf.h>
 
 void sbi_init(const void* fdt_blob) {
     // Build a view of the FDT
@@ -41,6 +41,8 @@ void sbi_init(const void* fdt_blob) {
     uart_init(g_uart_base);
 
     // TetOS IS ALIVE
-    uart_puts("BOOT: TetOS SBI early console ready\n");
-    uart_puts("Baguette crumbs of a new OS...\n");
+    kprintf("BOOT: FDT UART FOUND! @0x%x!\n", g_uart_base);
+    kprintf("Baguette crumbs of a new OS...\n");
+    kprintf("Test kprintf: char '%c', string \"%s\", int %d, uint %u, hex 0x%x, percent %%, nothing %t\n",
+            'A', "Stringing a chorus out of tune!", -1234, 5678u, 0x9abc);
 }

--- a/os/src/kernel/sbi_init.c
+++ b/os/src/kernel/sbi_init.c
@@ -18,7 +18,7 @@ void sbi_init(const void* fdt_blob) {
         // We don't have UART yet; use QEMU's default 0x10000000 as a last resort
         g_uart_base = 0x10000000ull;
         uart_init(g_uart_base);
-        uart_puts("BOOT: fdt_init failed, using hardcoded UART @0x10000000\n");
+        panic("BOOT: fdt_init failed!");
         return;
     }
 
@@ -33,7 +33,7 @@ void sbi_init(const void* fdt_blob) {
         // Fallback: common QEMU virt mapping
         g_uart_base = 0x10000000ull;
         uart_init(g_uart_base);
-        uart_puts("BOOT: stdout UART not found in FDT; fallback @0x10000000\n");
+        panic("BOOT: stdout UART not found in FDT!");
         return;
     }
 
@@ -41,12 +41,19 @@ void sbi_init(const void* fdt_blob) {
     g_uart_base   = (uintptr_t) base;
     uart_init(g_uart_base);
 
-    // Test panic
-    panic("boo"); // Get it because the kernel panics because it got scared
-
     // TetOS IS ALIVE
     kprintf("BOOT: FDT UART FOUND! @0x%x!\n", g_uart_base);
     kprintf("Baguette crumbs of a new OS...\n");
     kprintf("Test kprintf: char '%c', string \"%s\", int %d, uint %u, hex 0x%x, percent %%, nothing %t\n",
             'A', "Stringing a chorus out of tune!", -1234, 5678u, 0x9abc);
+
+    // Echo
+    kprintf("Type characters to echo:\n");
+    kprintf("tetos> ");
+    char input[128];
+    while (1) {
+        uart_gets(input, sizeof(input));
+        kprintf("\nYou typed: %s\n", input);
+        kprintf("tetos> ");
+    }
 }

--- a/os/src/lib/mini_lib.c
+++ b/os/src/lib/mini_lib.c
@@ -19,8 +19,8 @@ int strcmp(const char* s1, const char* s2) {
     return *(const unsigned char*) s1 - *(const unsigned char*) s2;
 }
 
-int strlen(const char* s) {
-    int n = 0;
+size_t strlen(const char* s) {
+    size_t n = 0;
     while (s[n]) n++;
 
     return n;

--- a/os/src/lib/mini_lib.c
+++ b/os/src/lib/mini_lib.c
@@ -19,8 +19,8 @@ int strcmp(const char* s1, const char* s2) {
     return *(const unsigned char*) s1 - *(const unsigned char*) s2;
 }
 
-size_t strlen(const char* s) {
-    size_t n = 0;
+int strlen(const char* s) {
+    int n = 0;
     while (s[n]) n++;
 
     return n;


### PR DESCRIPTION
This pull request introduces a basic interactive kernel monitor (shell) and a foundational kernel infrastructure for TetOS, including portable build improvements, console I/O, and error handling. Major changes include a new interactive monitor, a custom `kprintf` implementation, UART driver refactoring, improved portability in the `Makefile`, and a unified panic handling mechanism.

**Kernel infrastructure and monitor:**
- Added a basic kernel monitor (`kernel_monitor`) providing an interactive shell with built-in commands (`help`, `echo`, `panic`), input parsing, and command execution. [[1]](diffhunk://#diff-c30a1431be7bc9b024c298083f025c1d1c3f3e1b4a19f013b2fb016ff3f68cc3R1-R105) [[2]](diffhunk://#diff-918a4b8fda48cc4c76a7a46850776e9a30685303f08421cd7a2d965706719052R1-R11) [[3]](diffhunk://#diff-c71b4e94b2e4e5d4ab8918fc7488fb56e6b3a074559fd2ae8e35a5600ba62401R1-R9)
- Introduced new kernel entry and initialization flow: `kernel_entry` now calls `sbi_init` and then `kernel_main`, which launches the monitor. [[1]](diffhunk://#diff-fb383567c9e6798a1bcaed05599fbb6ad349bd047c33170315e02e3f60740870R1-R9) [[2]](diffhunk://#diff-c71b4e94b2e4e5d4ab8918fc7488fb56e6b3a074559fd2ae8e35a5600ba62401R1-R9) [[3]](diffhunk://#diff-03b9bc455c7942d2fdd0f21a6f9d5e3a4a26da41f141aa82cf2ba3fed25ece76L9-R9) [[4]](diffhunk://#diff-124e10c52a28914e581dd0774fbc9fa127eaf7b30694985aab91d7ea9434c955R1-R7)

**Console I/O and formatting:**
- Implemented a minimal `kprintf` with support for `%c`, `%s`, `%d`, `%u`, `%x`, and `%%`, using UART for output. [[1]](diffhunk://#diff-f2a149d88a7a486748b5d8893490578d8f0baf157873985a9ab62450449e038bR1-R96) [[2]](diffhunk://#diff-2ca3896fd4beb4cc7cd856e1ec5446173fcd4d6d29ef8dbbf1f74831f220852bR1-R11) [[3]](diffhunk://#diff-c52081e6e5ac82d8c298cb4e600587a8c48db9a3148a3874016ad6c129e97e4bL29-R34) [[4]](diffhunk://#diff-f4e0cebc4e18d9b81647b24cd0f8cc1d2d9a164e7d5bf3ee888017589aca82bbR4-R56)
- Refactored UART driver to use a global base address, simplified interface (no more passing `base`), and added input functions (`uart_getc`, `uart_gets`) for interactive input. [[1]](diffhunk://#diff-c52081e6e5ac82d8c298cb4e600587a8c48db9a3148a3874016ad6c129e97e4bR7-R8) [[2]](diffhunk://#diff-c52081e6e5ac82d8c298cb4e600587a8c48db9a3148a3874016ad6c129e97e4bL29-R34) [[3]](diffhunk://#diff-f4e0cebc4e18d9b81647b24cd0f8cc1d2d9a164e7d5bf3ee888017589aca82bbR4-R56)

**Error handling and panic:**
- Added a unified `panic` macro and implementation that prints a message and halts the system, used for fatal errors during boot and in the monitor. [[1]](diffhunk://#diff-019afc742e084ae6ab86fd4630cd2d88654e04905d4832154df61a006243e522R1-R10) [[2]](diffhunk://#diff-cf56b922344a42934d7214f399541357169a9f7a449ed18f1a307bd9976dd1cfR1-R12) [[3]](diffhunk://#diff-946103d74649d6ab5ee082e8ea7e9dbf6b981463f34e3719c5ce9728ae155e19L25-R19) [[4]](diffhunk://#diff-946103d74649d6ab5ee082e8ea7e9dbf6b981463f34e3719c5ce9728ae155e19L40-L59)

**Build system and portability:**
- Improved `Makefile` for better cross-platform compatibility (Windows/Unix), more robust source discovery, and new targets (`trace` for QEMU tracing). [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R10-R84) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L90-R121)

**Miscellaneous:**
- Fixed header guards, added missing includes, and corrected function signatures for consistency. [[1]](diffhunk://#diff-124e10c52a28914e581dd0774fbc9fa127eaf7b30694985aab91d7ea9434c955R1-R7) [[2]](diffhunk://#diff-2ca3896fd4beb4cc7cd856e1ec5446173fcd4d6d29ef8dbbf1f74831f220852bR1-R11) [[3]](diffhunk://#diff-918a4b8fda48cc4c76a7a46850776e9a30685303f08421cd7a2d965706719052R1-R11) [[4]](diffhunk://#diff-3d550aba0b500f607979b8a7f18c32fc1747a52af32bda53b501ab560b743529L9-R9) [[5]](diffhunk://#diff-f1c52e7397d1f7e4aa743011189a8230370f2fa97bb19800c4b991f23eef03b9L22-R23)

**References:**  
[[1]](diffhunk://#diff-c30a1431be7bc9b024c298083f025c1d1c3f3e1b4a19f013b2fb016ff3f68cc3R1-R105) [[2]](diffhunk://#diff-918a4b8fda48cc4c76a7a46850776e9a30685303f08421cd7a2d965706719052R1-R11) [[3]](diffhunk://#diff-c71b4e94b2e4e5d4ab8918fc7488fb56e6b3a074559fd2ae8e35a5600ba62401R1-R9) [[4]](diffhunk://#diff-fb383567c9e6798a1bcaed05599fbb6ad349bd047c33170315e02e3f60740870R1-R9) [[5]](diffhunk://#diff-03b9bc455c7942d2fdd0f21a6f9d5e3a4a26da41f141aa82cf2ba3fed25ece76L9-R9) [[6]](diffhunk://#diff-124e10c52a28914e581dd0774fbc9fa127eaf7b30694985aab91d7ea9434c955R1-R7) [[7]](diffhunk://#diff-f2a149d88a7a486748b5d8893490578d8f0baf157873985a9ab62450449e038bR1-R96) [[8]](diffhunk://#diff-2ca3896fd4beb4cc7cd856e1ec5446173fcd4d6d29ef8dbbf1f74831f220852bR1-R11) [[9]](diffhunk://#diff-c52081e6e5ac82d8c298cb4e600587a8c48db9a3148a3874016ad6c129e97e4bL29-R34) [[10]](diffhunk://#diff-f4e0cebc4e18d9b81647b24cd0f8cc1d2d9a164e7d5bf3ee888017589aca82bbR4-R56) [[11]](diffhunk://#diff-c52081e6e5ac82d8c298cb4e600587a8c48db9a3148a3874016ad6c129e97e4bR7-R8) [[12]](diffhunk://#diff-019afc742e084ae6ab86fd4630cd2d88654e04905d4832154df61a006243e522R1-R10) [[13]](diffhunk://#diff-cf56b922344a42934d7214f399541357169a9f7a449ed18f1a307bd9976dd1cfR1-R12) [[14]](diffhunk://#diff-946103d74649d6ab5ee082e8ea7e9dbf6b981463f34e3719c5ce9728ae155e19L25-R19) [[15]](diffhunk://#diff-946103d74649d6ab5ee082e8ea7e9dbf6b981463f34e3719c5ce9728ae155e19L40-L59) [[16]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R10-R84) [[17]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L90-R121) [[18]](diffhunk://#diff-3d550aba0b500f607979b8a7f18c32fc1747a52af32bda53b501ab560b743529L9-R9) [[19]](diffhunk://#diff-f1c52e7397d1f7e4aa743011189a8230370f2fa97bb19800c4b991f23eef03b9L22-R23)

**This summary was generated by GitHub Copilot.**